### PR TITLE
Add automated cases to demonstrate archiving bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+wf-final*.yaml
+*.swp

--- a/argo-workflows/values.archives.yaml
+++ b/argo-workflows/values.archives.yaml
@@ -1,0 +1,34 @@
+argo-workflows:
+  controller:
+    workflowDefaults:
+      spec:
+        ttlStrategy:
+          secondsAfterCompletion: 84600 # 1 day
+    persistence:
+      archive: true
+      postgresql:
+        host: postgres.postgres.svc.cluster.local
+        port: 5432
+        database: workflow
+        tableName: argo_workflows
+        userNameSecret:
+          name: argo-postgres-config
+          key: username
+        passwordSecret:
+          name: argo-postgres-config
+          key: password
+        ssl: false
+        sslmode: disable
+  useDefaultArtifactRepo: true
+  artifactRepository:
+    archiveLogs: true
+    s3:
+      bucket: workflows
+      endpoint: minio.minio.svc.cluster.local:9000
+      insecure: true
+      accessKeySecret:
+        name: minio-creds
+        key: accesskey
+      secretKeySecret:
+        name: minio-creds
+        key: secretkey

--- a/argo-workflows/values.yaml
+++ b/argo-workflows/values.yaml
@@ -18,26 +18,9 @@ argo-workflows:
     workflowDefaults:
       spec:
         serviceAccountName: argo-workflow
-        ttlStrategy:
-          secondsAfterCompletion: 84600 # 1 day
     workflowNamespaces:
       - argo
       - default
-    persistence:
-      archive: true
-      postgresql:
-        host: postgres.postgres.svc.cluster.local
-        port: 5432
-        database: workflow
-        tableName: argo_workflows
-        userNameSecret:
-          name: argo-postgres-config
-          key: username
-        passwordSecret:
-          name: argo-postgres-config
-          key: password
-        ssl: false
-        sslmode: disable
   executor:
     image: {}
       # registry: our-harbor-cache/quay.io
@@ -79,18 +62,6 @@ argo-workflows:
     #   rbac:
     #     enabled: true
   useDefaultArtifactRepo: true
-  artifactRepository:
-    archiveLogs: true
-    s3:
-      bucket: workflows
-      endpoint: minio.minio.svc.cluster.local:9000
-      insecure: true
-      accessKeySecret:
-        name: minio-creds
-        key: accesskey
-      secretKeySecret:
-        name: minio-creds
-        key: secretkey
   workflow:
     serviceAccount:
       create: true

--- a/down.sh
+++ b/down.sh
@@ -1,0 +1,3 @@
+#!/bin/bash -xeu
+
+k3d cluster delete workflow-archiving

--- a/run-all.sh
+++ b/run-all.sh
@@ -1,0 +1,10 @@
+#!/bin/bash -xeu
+
+export BATCH_MODE=1
+SCRIPTPATH="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
+
+"${SCRIPTPATH}/up-no-archives.sh"
+"${SCRIPTPATH}/up-with-archives.sh"
+"${SCRIPTPATH}/up-archives-after-workflow.sh"
+
+diff -y wf-final-archive.yaml wf-final-archive-after-workflow.yaml

--- a/up-archives-after-workflow.sh
+++ b/up-archives-after-workflow.sh
@@ -1,0 +1,57 @@
+#!/bin/bash -xeu
+
+# Create cluster, install deps
+k3d cluster create --config k3d.conf
+kubectl get pods -Aw &
+kubectl create namespace minio && kubectl -n minio apply -f minio
+kubectl create namespace postgres && kubectl -n postgres apply -f postgres
+kubectl create namespace argo
+kubectl apply -n argo -f workflows-additions
+
+# Install Argo w/out archive
+cd argo-workflows
+helm dependency update
+helm template -n argo  argo-workflows -f values.yaml . > todeploy.yaml
+kubectl apply -n argo -f todeploy.yaml
+kubectl get workflows -Aw &
+kubectl -n argo rollout status deployment/argo-workflows-workflow-controller
+kubectl -n argo rollout status deployment/argo-workflows-server
+cd ..
+
+# Create and wait for workflow to finish
+wf_name=$(kubectl -n argo create -f hello-world/hello-world.yaml -o name | awk -F '/' '{ print $2 }')
+argo -n argo wait "${wf_name}"
+
+# Add archive to Argo, wait for update
+cd argo-workflows
+helm dependency update
+helm template -n argo  argo-workflows -f values.yaml -f values.archives.yaml . > todeploy.yaml
+kubectl apply -n argo -f todeploy.yaml
+kubectl -n argo rollout restart deployment/argo-workflows-workflow-controller
+kubectl -n argo rollout restart deployment/argo-workflows-server
+kubectl -n argo rollout status deployment/argo-workflows-server
+kubectl -n argo rollout status deployment/argo-workflows-workflow-controller
+cd ..
+sleep 3
+kubectl -n argo port-forward svc/argo-workflows-server 2746:2746 &
+sleep 3
+
+# Delete workflow, check archive
+kubectl -n argo get workflow "${wf_name}" -o yaml | tee /dev/stderr > wf-final-archive-after-workflow.yaml
+kubectl -n argo delete workflow "${wf_name}"
+if ! ARGO_SERVER=localhost:2746 ARGO_TOKEN='BEARER foo' ARGO_INSECURE_SKIP_VERIFY=true argo -n argo archive get "${wf_name}"; then
+    echo 'Workflow was not archived!'
+fi
+
+# Debugging
+if [ -z "${BATCH_MODE:-}" ]; then
+    if which xdg-open; then
+        xdg-open https://localhost:2746/archived-workflows
+    elif which open; then
+        open https://localhost:2746/archived-workflows
+    fi
+    read -p "Paused, press enter to clean up cluster"
+fi
+
+# Cleanup
+k3d cluster delete workflow-archiving

--- a/up-no-archives.sh
+++ b/up-no-archives.sh
@@ -1,0 +1,42 @@
+#!/bin/bash -xeu
+
+# Create cluster, install deps
+k3d cluster create --config k3d.conf
+kubectl get pods -Aw &
+kubectl create namespace argo
+kubectl apply -n argo -f workflows-additions
+
+# Install Argo w/out archive
+cd argo-workflows
+helm dependency update
+helm template -n argo  argo-workflows -f values.yaml . > todeploy.yaml
+kubectl apply -n argo -f todeploy.yaml
+kubectl get workflows -Aw &
+kubectl -n argo rollout status deployment/argo-workflows-workflow-controller
+kubectl -n argo rollout status deployment/argo-workflows-server
+cd ..
+kubectl -n argo port-forward --address 0.0.0.0 svc/argo-workflows-server 2746:2746 &
+
+# Create and wait for workflow to finish
+wf_name=$(kubectl -n argo create -f hello-world/hello-world.yaml -o name | awk -F '/' '{ print $2 }')
+argo -n argo wait "${wf_name}"
+
+# Delete workflow, check archive
+kubectl -n argo get workflow "${wf_name}" -o yaml | tee /dev/stderr > wf-final-no-archive.yaml
+kubectl -n argo delete workflow "${wf_name}"
+if ! ARGO_SERVER=localhost:2746 ARGO_TOKEN='BEARER foo' ARGO_INSECURE_SKIP_VERIFY=true argo -n argo archive get "${wf_name}"; then
+    echo 'Workflow was not archived!'
+fi
+
+# Debugging
+if [ -z "${BATCH_MODE:-}" ]; then
+    if which xdg-open; then
+        xdg-open https://localhost:2746
+    elif which open; then
+        open https://localhost:2746
+    fi
+    read -p "Paused, press enter to clean up cluster"
+fi
+
+# Cleanup
+k3d cluster delete workflow-archiving

--- a/up-with-archives.sh
+++ b/up-with-archives.sh
@@ -1,0 +1,44 @@
+#!/bin/bash -xeu
+
+# Create cluster, install deps
+k3d cluster create --config k3d.conf
+kubectl get pods -Aw &
+kubectl create namespace minio && kubectl -n minio apply -f minio
+kubectl create namespace postgres && kubectl -n postgres apply -f postgres
+kubectl create namespace argo
+kubectl apply -n argo -f workflows-additions
+
+# Install Argo w/out archive
+cd argo-workflows
+helm dependency update
+helm template -n argo  argo-workflows -f values.yaml -f values.archives.yaml . > todeploy.yaml
+kubectl apply -n argo -f todeploy.yaml
+kubectl get workflows -Aw &
+kubectl -n argo rollout status deployment/argo-workflows-workflow-controller
+kubectl -n argo rollout status deployment/argo-workflows-server
+cd ..
+kubectl -n argo port-forward svc/argo-workflows-server 2746:2746 &
+
+# Create and wait for workflow to finish
+wf_name=$(kubectl -n argo create -f hello-world/hello-world.yaml -o name | awk -F '/' '{ print $2 }')
+argo -n argo wait "${wf_name}"
+
+# Delete workflow, check archive
+kubectl -n argo get workflow "${wf_name}" -o yaml | tee /dev/stderr > wf-final-archive.yaml
+kubectl -n argo delete workflow "${wf_name}"
+if ! ARGO_SERVER=localhost:2746 ARGO_TOKEN='BEARER foo' ARGO_INSECURE_SKIP_VERIFY=true argo -n argo archive get "${wf_name}"; then
+    echo 'Workflow was not archived!'
+fi
+
+# Debugging
+if [ -z "${BATCH_MODE:-}" ]; then
+    if which xdg-open; then
+        xdg-open https://localhost:2746
+    elif which open; then
+        open https://localhost:2746
+    fi
+    read -p "Paused, press enter to clean up cluster"
+fi
+
+# Cleanup
+k3d cluster delete workflow-archiving


### PR DESCRIPTION
Following up from our conversation on Friday.

I added three automated test cases: With archive enabled, without archive enabled, and with archive starting disabled, but enabled after the workflow completes. The first two behave as expected, but the third does not archive the workflow when manually deleted. This is confirmed by using the argo cli, viewing in the browser, as well as diff'ing the workflow YAML's prior to being deleted, in which the post-enabled archive case shows the archive label to be missing.

I believe this reproduces the exact situation I am observing on my instance.